### PR TITLE
Changed library link for TMC2130 to TMCStepper library

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1298,8 +1298,8 @@
  * in your `pins_MYBOARD.h` file. (e.g., RAMPS 1.4 uses AUX3 pins `X_CS_PIN 53`, `Y_CS_PIN 49`, etc.).
  * You may also use software SPI if you wish to use general purpose IO pins.
  *
- * The TMC2130Stepper library is required for this stepper driver.
- * https://github.com/teemuatlut/TMC2130Stepper
+ * The TMCStepper library is required for this stepper driver.
+ * https://github.com/teemuatlut/TMCStepper
  *
  * To use TMC2208 stepper UART-configurable stepper drivers
  * connect #_SERIAL_TX_PIN to the driver side PDN_UART pin with a 1K resistor.


### PR DESCRIPTION
As  recommended by the library author in #12608 I changed the comment and the link to the correct library

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

As discussed in #12608 the correct library to include for TMC 2130 drivers is TMCStepper rather than TMC2130Stepper. I updated the comment only

### Benefits
Avoids users using the wrong library

### Related Issues

#12608